### PR TITLE
Update StorageManager.Estimate example

### DIFF
--- a/files/en-us/web/api/storagemanager/estimate/index.md
+++ b/files/en-us/web/api/storagemanager/estimate/index.md
@@ -50,7 +50,7 @@ In this example, we obtain the usage estimates and present the percentage of sto
 ```html
 <label>
   You're currently using about <output id="percent"> </output>% of your
-  available storage.
+  estimated storage quota (<output id="quota"></output>).
 </label>
 ```
 
@@ -62,6 +62,7 @@ navigator.storage.estimate().then((estimate) => {
     (estimate.usage / estimate.quota) *
     100
   ).toFixed(2);
+  document.getElementById("quota").value = (estimate.quota / 1024 / 1024).toFixed(2) + "MB";
 });
 ```
 

--- a/files/en-us/web/api/storagemanager/estimate/index.md
+++ b/files/en-us/web/api/storagemanager/estimate/index.md
@@ -62,7 +62,8 @@ navigator.storage.estimate().then((estimate) => {
     (estimate.usage / estimate.quota) *
     100
   ).toFixed(2);
-  document.getElementById("quota").value = (estimate.quota / 1024 / 1024).toFixed(2) + "MB";
+  document.getElementById("quota").value =
+    (estimate.quota / 1024 / 1024).toFixed(2) + "MB";
 });
 ```
 


### PR DESCRIPTION
### Description

This updates the StorageManager.Estimate example to be more useful, as the current storage estimate just displays 0.0% if you are not using any storage and its impossible to see how much space the browser estimates for you.

![image](https://github.com/Strepto/content/assets/3185998/5b1cd204-eff5-43d0-a1e6-b68261fca15a)

https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate

This changes the text to:
`You're currently using about 0.00% of your estimated storage quota (571951.80MB).`

### Motivation

It helps the reader understand what values the current browser has without doing manual changes, and is a simple change to the example.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
